### PR TITLE
Fix incorrect ts-loader configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = ({ mode, presets } = { mode: "production", presets: [] }) => {
           enforce: "pre",
         },
         {
-          test: /\.ts?$/,
+          test: /\.tsx?$/,
           use: 'ts-loader',
           exclude: /node_modules/
         },


### PR DESCRIPTION
This PR fixes the test used to decide if a file should be loaded using ts-loader.

The test was `/\.ts?$/`, which would match a file named `banana.ts`, or `banana.t`, but not `banana.tsx`. I don’t think this was the intention :-).

The problem is that the test is a Regular Expression, not a glob. In RegExp syntax, `?` means that the previous character is optional.

Therefore the correct test is `/\.tsx?$/`, which will match files ending `.ts` or `.tsx`.